### PR TITLE
Add a version to manifest as required by HA core-2021.6.X

### DIFF
--- a/custom_components/snmp_stats/manifest.json
+++ b/custom_components/snmp_stats/manifest.json
@@ -5,5 +5,6 @@
     "dependencies": [],
     "codeowners": ["@weltmeyer"],
     "requirements": ["pysnmp"],
-    "config_flow": true
+    "config_flow": true,
+    "version": "0.1.0"
 }


### PR DESCRIPTION
Fixes #6.

From HA core-2021.6 all components must declare a version in the manifest to be loaded. I chose 0.1.0 as no tagged versions exists, but it can be anything you like.